### PR TITLE
Add aloe documention for the CLI

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -108,13 +108,3 @@ signs:
       - "--output-signature=${signature}"
       - "--yes" # needed on cosign 2.0.0+
     artifacts: checksum
-
-# the image signing doesn't seem to work when using ko to build the image
-#docker_signs:
-#  - cmd: cosign
-#    args:
-#      - "sign"
-#      - "ghcr.io/tfadeyi/auth0-simple-exporter@${digest}"
-#      - "--yes"
-#    artifacts: all
-#    output: true

--- a/docs/errors_definitions/clean_artefacts_error.md
+++ b/docs/errors_definitions/clean_artefacts_error.md
@@ -1,0 +1,18 @@
+---
+title: Error Removing Previous Artefacts
+code: clean_artefacts_error
+---
+
+## Error Removing Previous Artefacts
+
+**Code**: clean_artefacts_error
+
+### Summary
+
+The tool has failed to delete the artefacts from the previous execution.
+
+### Details
+
+The tool has failed to delete the artefacts from the previous execution.
+Try manually deleting them before running the tool again.
+

--- a/docs/errors_definitions/invalid_output_format.md
+++ b/docs/errors_definitions/invalid_output_format.md
@@ -1,0 +1,17 @@
+---
+title: invalid_output_format
+code: invalid_output_format
+---
+
+## invalid_output_format
+
+**Code**: invalid_output_format
+
+### Summary
+
+the output format passed to --format was invalid, valid: json,yaml
+
+### Details
+
+&lt;nil&gt;
+

--- a/docs/errors_definitions/parsing_golang_error.md
+++ b/docs/errors_definitions/parsing_golang_error.md
@@ -1,0 +1,19 @@
+---
+title: parsing_golang_error
+code: parsing_golang_error
+---
+
+## parsing_golang_error
+
+**Code**: parsing_golang_error
+
+### Summary
+
+there was an error parsing the application source file
+
+### Details
+
+The parser was processing the source file when it encountered an error
+This could be because the file doesn&#39;t exist or the file not being a golang source file
+Make sure the file is a golang source file
+

--- a/docs/errors_definitions/validate_not_implemented.md
+++ b/docs/errors_definitions/validate_not_implemented.md
@@ -1,0 +1,17 @@
+---
+title: validate_not_implemented
+code: validate_not_implemented
+---
+
+## validate_not_implemented
+
+**Code**: validate_not_implemented
+
+### Summary
+
+spec validate command has not been implemented yet
+
+### Details
+
+specification validate command has not been implemented yet, will be implemented shortly
+

--- a/docs/info.md
+++ b/docs/info.md
@@ -1,0 +1,24 @@
+---
+title: aloe_cli
+---
+
+## aloe_cli
+
+**Application**: aloe_cli
+**Version**: v0.0.1
+
+### Description
+
+Aloe CLI application
+
+### Error definitions
+
+
+  * **clean_artefacts_error**: The tool has failed to delete the artefacts from the previous execution..
+
+  * **invalid_output_format**: the output format passed to --format was invalid, valid: json,yaml.
+
+  * **parsing_golang_error**: there was an error parsing the application source file.
+
+  * **validate_not_implemented**: spec validate command has not been implemented yet.
+

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -134,7 +134,7 @@ func writeAll(stdout bool, files map[string][]byte) error {
 
 func getMarkdownFromSpec(spec *api.Application) (map[string][]byte, error) {
 	files := make(map[string][]byte)
-	root := fmt.Sprintf("./%s/info.md", spec.Name)
+	root := fmt.Sprintf("./%s/info.md", "docs")
 	// parse application general information
 	tmpl, err := template.New(spec.Name).Parse(applicationInfoMarkdownTmpl)
 	if err != nil {
@@ -159,7 +159,7 @@ func getMarkdownFromSpec(spec *api.Application) (map[string][]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		path := fmt.Sprintf("./%s/errors_definitions/%s.md", spec.Name, code)
+		path := fmt.Sprintf("./%s/errors_definitions/%s.md", "docs", code)
 		if _, ok := files[path]; !ok {
 			files[path] = buf.Bytes()
 		}

--- a/internal/generate/templates/markdown/info.md.tmpl
+++ b/internal/generate/templates/markdown/info.md.tmpl
@@ -2,9 +2,9 @@
 title: {{ .Name }}
 ---
 
-## {{ .Title }}
+## {{ .Name }}
 
-**Application**: {{ .Title }}
+**Application**: {{ .Name }}
 **Version**: {{ .Version }}
 
 ### Description
@@ -13,3 +13,6 @@ title: {{ .Name }}
 
 ### Error definitions
 
+{{ range $key, $value := .ErrorsDefinitions }}
+  * **{{ $key }}**: {{ $value.Summary }}.
+{{ end }}

--- a/main.go
+++ b/main.go
@@ -11,8 +11,8 @@ import (
 )
 
 // @aloe name aloe_cli
-// @aloe url https://github.com/tfadeyi
-// @aloe version v2
+// @aloe url https://tfadeyi.github.io
+// @aloe version v0.0.1
 // @aloe description Aloe CLI application
 
 func main() {


### PR DESCRIPTION
This PR adds an example `docs` dir with markdown for the error objects.